### PR TITLE
No threads, same behavior

### DIFF
--- a/pcap_thread.h
+++ b/pcap_thread.h
@@ -184,9 +184,9 @@ struct pcap_thread_pcaplist {
     char*                   name;
     pcap_t*                 pcap;
     void*                   user;
+    int                     running;
 #ifdef HAVE_PTHREAD
     pthread_t               thread;
-    int                     running;
     pthread_cond_t*         queue_cond;
     pthread_mutex_t*        queue_mutex;
     size_t                  queue_size;


### PR DESCRIPTION
Fix behavior of the none threaded engine of `pcap_thread_run()`, end only after all pcaps are done.
Add "exit after num seconds" option to `hexdump`.
Add more error handling to `hexdump`.