### PR TITLE
More tweaks to thread handling, locking, stopping and errors.

### DIFF
--- a/pcap_thread.h
+++ b/pcap_thread.h
@@ -178,6 +178,8 @@ struct pcap_thread {
     struct timeval          timedrun;
 };
 
+#define PCAP_THREAD_SET_ERRBUF(x, y) strncpy(x->errbuf, y, sizeof(x->errbuf) - 1)
+
 #ifdef HAVE_PTHREAD
 #define PCAP_THREAD_PCAPLIST_T_INIT { \
     0, 0, 0, 0, 0, 0, \


### PR DESCRIPTION
A situation could occur, because `pcap_thread_stop()` was canceling
and joining threads, that if called from a PCAP thread would result
in a deadlock.

- `pcap_thread_stop()` can now be safely called from any thread
- PCAP threads are not handled within `pcap_thread_run()`
- Store related system call in `errbuf` for all `PCAP_THREAD_ERRNO` errors, retrieve system call with `pcap_thread_errbuf()`
- Detach PCAP threads for easier clean up
- Use `pthread_cleanup_push()` to unlock mutex on cancellation
- Use `pcap_breakloop()` and `pthread_cancel()` to correctly cancel processing