### PR TITLE
Packet Layer Callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ if you have support, launch a thread per `pcap_t` for the collection which
 is then feeded back to the main thread using a queue before being passed on
 to the callback.
 
+Additional callbacks exists for simplifying the handling of various transport
+layers, based on [pcap_layers](https://github.com/wessels/pcap_layers) by
+Duane Wessels (The Measurement Factory, Inc.), such as ether, VLAN, IP, IPv4,
+IPv6, GRE tunnels, UDP and TCP.
+
 ## Usage
 
 Here is a short example how to use this helper, see the hexdump directory

--- a/hexdump/config.h.in
+++ b/hexdump/config.h.in
@@ -1,5 +1,8 @@
 /* config.h.in.  Generated from configure.ac by autoheader.  */
 
+/* Define to 1 if you have the <endian.h> header file. */
+#undef HAVE_ENDIAN_H
+
 /* Define to 1 if you have the <inttypes.h> header file. */
 #undef HAVE_INTTYPES_H
 
@@ -54,6 +57,9 @@
 
 /* Define to 1 if you have the <string.h> header file. */
 #undef HAVE_STRING_H
+
+/* Define to 1 if you have the <sys/endian.h> header file. */
+#undef HAVE_SYS_ENDIAN_H
 
 /* Define to 1 if you have the <sys/stat.h> header file. */
 #undef HAVE_SYS_STAT_H

--- a/m4/ax_pcap_thread.m4
+++ b/m4/ax_pcap_thread.m4
@@ -1,6 +1,7 @@
 AC_DEFUN([AX_PCAP_THREAD_PCAP], [
     AC_CHECK_LIB([pcap], [pcap_open_live], [], AC_MSG_ERROR([libpcap not found]))
     AC_CHECK_HEADER([pcap/pcap.h], [], [AC_MSG_ERROR([libpcap header not found])])
+    AC_CHECK_HEADERS([endian.h sys/endian.h])
     AC_CHECK_FUNCS([pcap_create pcap_set_tstamp_precision pcap_set_immediate_mode])
     AC_CHECK_FUNCS([pcap_set_tstamp_type pcap_setdirection sched_yield])
     AC_CHECK_FUNCS([pcap_open_offline_with_tstamp_precision pcap_activate])


### PR DESCRIPTION
Implement callbacks for different packet layers to simplify processing,
based on `pcap_layers` by Duane Wessels (@wessels).

Following callback exists:
- `pcap_thread_set_callback_ether()`
- `pcap_thread_set_callback_null()`
- `pcap_thread_set_callback_loop()`
- `pcap_thread_set_callback_ieee802()`
- `pcap_thread_set_callback_gre()`
- `pcap_thread_set_callback_ip()`
- `pcap_thread_set_callback_ipv4()`
- `pcap_thread_set_callback_ipv6()`
- `pcap_thread_set_callback_udp()`
- `pcap_thread_set_callback_tcp()`

For more layers, only one callback can be set so you can't intersect
the packet processing in the middle at, for example, gre. There are a
few layers that can have multiple callback:
- IPv4 and IPv6 callbacks can be set at the same time
- UDP and TCP callbacks can be set at the same time

Layer processing is enabled by `pcap_thread_set_use_layers()` and is
used if set and no callback has been set (`pcap_thread_set_callback()`).

For any packet that the layers does not understand or is invalid, use
`pcap_thread_set_callback_invalid()` to set a handler for them and
check `packet->state` what went wrong.

New option in `hexdump`, `-L <layer>` enabled capturing for the given
layer and dumps the payload for it and not the whole packet.