### PR TITLE
Ability to reuse pcap_thread

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ compiler:
   - clang
   - gcc
 before_install:
-  - sudo apt-get -qq update
+  - sudo apt-get -qq update || true
   - sudo apt-get install -y libpcap-dev
 script:
   - cd hexdump

--- a/pcap_thread.h
+++ b/pcap_thread.h
@@ -394,6 +394,7 @@ pcap_direction_t pcap_thread_direction(const pcap_thread_t* pcap_thread);
 int pcap_thread_set_direction(pcap_thread_t* pcap_thread, const pcap_direction_t direction);
 const char* pcap_thread_filter(const pcap_thread_t* pcap_thread);
 int pcap_thread_set_filter(pcap_thread_t* pcap_thread, const char* filter, const size_t filter_len);
+int pcap_thread_clear_filter(pcap_thread_t* pcap_thread);
 int pcap_thread_filter_errno(const pcap_thread_t* pcap_thread);
 int pcap_thread_filter_optimze(const pcap_thread_t* pcap_thread);
 int pcap_thread_set_filter_optimize(pcap_thread_t* pcap_thread, const int filter_optimize);


### PR DESCRIPTION
- `pcap_thread_close()` only frees/clears things related to running
- fix `pcap_thread_close()`, also clear stepping pointer
- add `pcap_thread_clear_filter()` for releasing filter on non-allocated
  pcap_threads
- fix `pcap_thread_set_filter()`, check for memory issue