### PR TITLE
Dispatch, error, hexdump, format

### DIFF
--- a/fmt.sh
+++ b/fmt.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-clang-format-4.0 \
+clang-format \
     -style=file \
     -i \
     pcap_thread*.c \

--- a/hexdump/hexdump.c
+++ b/hexdump/hexdump.c
@@ -732,11 +732,11 @@ int main(int argc, char** argv)
             exit(3);
         }
         if (filter_left != MAX_FILTER_SIZE) {
-            strncat(filterp, " ", 1);
+            memcpy(filterp, " ", 1);
             filterp++;
             filter_left--;
         }
-        strncat(filterp, argv[optind++], len);
+        memcpy(filterp, argv[optind++], len);
         filterp += len;
         filter_left -= len;
     }

--- a/pcap_thread.c
+++ b/pcap_thread.c
@@ -1322,7 +1322,7 @@ static void pcap_thread_callback(u_char* user, const struct pcap_pkthdr* pkthdr,
             pcap_thread_callback_linux_sll((void*)pcaplist, &packet, pkt, length);
         return;
 
-    /* TODO: These might be interesting to implement
+        /* TODO: These might be interesting to implement
         case DLT_IPNET:
         case DLT_PKTAP:
         */
@@ -3206,7 +3206,7 @@ static void* _thread(void* vp)
     while (pcaplist->running) {
         pthread_testcancel();
         ret = pcap_loop(pcaplist->pcap, -1, _callback, (u_char*)pcaplist);
-        if (ret == -1) {
+        if (ret == PCAP_ERROR) {
             /* TODO: Store pcap_loop() error */
             break;
         }
@@ -3244,6 +3244,12 @@ static void _callback2(u_char* user, const struct pcap_pkthdr* pkthdr, const u_c
     } else {
         pcaplist->running = 0;
     }
+
+    if (pcaplist->timedrun
+        && (pkthdr->ts.tv_sec > pcaplist->end.tv_sec
+            || (pkthdr->ts.tv_sec == pcaplist->end.tv_sec && (pkthdr->ts.tv_usec * 1000) >= pcaplist->end.tv_nsec))) {
+        pcap_breakloop(pcaplist->pcap);
+    }
 }
 
 int pcap_thread_run(pcap_thread_t* pcap_thread)
@@ -3264,18 +3270,18 @@ int pcap_thread_run(pcap_thread_t* pcap_thread)
     }
     if (pcap_thread->use_layers
         && !(pcap_thread->callback_linux_sll
-               || pcap_thread->callback_ether
-               || pcap_thread->callback_null
-               || pcap_thread->callback_loop
-               || pcap_thread->callback_ieee802
-               || pcap_thread->callback_gre
-               || pcap_thread->callback_ip
-               || pcap_thread->callback_ipv4
-               || pcap_thread->callback_ipv6
-               || pcap_thread->callback_icmp
-               || pcap_thread->callback_icmpv6
-               || pcap_thread->callback_udp
-               || pcap_thread->callback_tcp)) {
+             || pcap_thread->callback_ether
+             || pcap_thread->callback_null
+             || pcap_thread->callback_loop
+             || pcap_thread->callback_ieee802
+             || pcap_thread->callback_gre
+             || pcap_thread->callback_ip
+             || pcap_thread->callback_ipv4
+             || pcap_thread->callback_ipv6
+             || pcap_thread->callback_icmp
+             || pcap_thread->callback_icmpv6
+             || pcap_thread->callback_udp
+             || pcap_thread->callback_tcp)) {
         return PCAP_THREAD_NOCALLBACK;
     }
     if (pcap_thread->running) {
@@ -3529,7 +3535,9 @@ int pcap_thread_run(pcap_thread_t* pcap_thread)
                 pcaplist->ipv6_frag_ctx      = pcap_thread->callback_ipv6_frag.new(pcap_thread->callback_ipv6_frag.conf, pcaplist->user);
                 pcaplist->have_ipv6_frag_ctx = 1;
             }
-            pcaplist->running = 1;
+            pcaplist->running  = 1;
+            pcaplist->timedrun = timedrun;
+            pcaplist->end      = end;
         }
 
         t1.tv_sec  = pcap_thread->timeout / 1000;
@@ -3590,12 +3598,13 @@ int pcap_thread_run(pcap_thread_t* pcap_thread)
                 }
 
                 packets = pcap_dispatch(pcaplist->pcap, -1, _callback2, (u_char*)pcaplist);
-                if (packets == -1) {
+                if (packets == PCAP_ERROR) {
                     pcap_thread->status = -1;
                     PCAP_THREAD_SET_ERRBUF(pcap_thread, "pcap_dispatch()");
                     pcap_thread->running = 0;
                     return PCAP_THREAD_EPCAP;
-                } else if (packets == -2 || (pcaplist->is_offline && !packets)) {
+                }
+                if (pcaplist->is_offline && !packets) {
                     pcaplist->running = 0;
                 }
             }
@@ -3620,18 +3629,18 @@ int pcap_thread_next(pcap_thread_t* pcap_thread)
     }
     if (pcap_thread->use_layers
         && !(pcap_thread->callback_linux_sll
-               || pcap_thread->callback_ether
-               || pcap_thread->callback_null
-               || pcap_thread->callback_loop
-               || pcap_thread->callback_ieee802
-               || pcap_thread->callback_gre
-               || pcap_thread->callback_ip
-               || pcap_thread->callback_ipv4
-               || pcap_thread->callback_ipv6
-               || pcap_thread->callback_icmp
-               || pcap_thread->callback_icmpv6
-               || pcap_thread->callback_udp
-               || pcap_thread->callback_tcp)) {
+             || pcap_thread->callback_ether
+             || pcap_thread->callback_null
+             || pcap_thread->callback_loop
+             || pcap_thread->callback_ieee802
+             || pcap_thread->callback_gre
+             || pcap_thread->callback_ip
+             || pcap_thread->callback_ipv4
+             || pcap_thread->callback_ipv6
+             || pcap_thread->callback_icmp
+             || pcap_thread->callback_icmpv6
+             || pcap_thread->callback_udp
+             || pcap_thread->callback_tcp)) {
         return PCAP_THREAD_NOCALLBACK;
     }
     if (pcap_thread->running) {

--- a/pcap_thread.h
+++ b/pcap_thread.h
@@ -509,6 +509,7 @@ struct pcap_thread {
     PCAP_THREAD_PCAPLIST_T_INIT_THREAD \
     { 0, 0 }, \
     0, \
+    0, { 0, 0 } \
 }
 /* clang-format on */
 
@@ -535,6 +536,9 @@ struct pcap_thread_pcaplist {
     struct bpf_program bpf;
 
     pcap_thread_callback_t layer_callback;
+
+    int             timedrun;
+    struct timespec end;
 };
 
 const char* pcap_thread_version_str(void);
@@ -544,57 +548,57 @@ int pcap_thread_version_minor(void);
 int pcap_thread_version_patch(void);
 
 pcap_thread_t* pcap_thread_create(void);
-void pcap_thread_free(pcap_thread_t* pcap_thread);
+void           pcap_thread_free(pcap_thread_t* pcap_thread);
 
-int pcap_thread_use_threads(const pcap_thread_t* pcap_thread);
-int pcap_thread_set_use_threads(pcap_thread_t* pcap_thread, const int use_threads);
-int pcap_thread_use_layers(const pcap_thread_t* pcap_thread);
-int pcap_thread_set_use_layers(pcap_thread_t* pcap_thread, const int use_layers);
-pcap_thread_queue_mode_t pcap_thread_queue_mode(const pcap_thread_t* pcap_thread);
-int pcap_thread_set_queue_mode(pcap_thread_t* pcap_thread, const pcap_thread_queue_mode_t queue_mode);
-struct timeval pcap_thread_queue_wait(const pcap_thread_t* pcap_thread);
-int pcap_thread_set_queue_wait(pcap_thread_t* pcap_thread, const struct timeval queue_wait);
-pcap_thread_queue_mode_t pcap_thread_callback_queue_mode(const pcap_thread_t* pcap_thread);
-int pcap_thread_set_callback_queue_mode(pcap_thread_t* pcap_thread, const pcap_thread_queue_mode_t callback_queue_mode);
-struct timeval pcap_thread_callback_queue_wait(const pcap_thread_t* pcap_thread);
-int pcap_thread_set_callback_queue_wait(pcap_thread_t* pcap_thread, const struct timeval callback_queue_wait);
-int pcap_thread_snapshot(const pcap_thread_t* pcap_thread);
-int pcap_thread_snaplen(const pcap_thread_t* pcap_thread);
-int pcap_thread_set_snaplen(pcap_thread_t* pcap_thread, const int snaplen);
-int pcap_thread_promiscuous(const pcap_thread_t* pcap_thread);
-int pcap_thread_set_promiscuous(pcap_thread_t* pcap_thread, const int promiscuous);
-int pcap_thread_monitor(const pcap_thread_t* pcap_thread);
-int pcap_thread_set_monitor(pcap_thread_t* pcap_thread, const int monitor);
-int pcap_thread_timeout(const pcap_thread_t* pcap_thread);
-int pcap_thread_set_timeout(pcap_thread_t* pcap_thread, const int timeout);
-int pcap_thread_buffer_size(const pcap_thread_t* pcap_thread);
-int pcap_thread_set_buffer_size(pcap_thread_t* pcap_thread, const int buffer_size);
-int pcap_thread_timestamp_type(const pcap_thread_t* pcap_thread);
-int pcap_thread_set_timestamp_type(pcap_thread_t* pcap_thread, const int timestamp_type);
-int pcap_thread_timestamp_precision(const pcap_thread_t* pcap_thread);
-int pcap_thread_set_timestamp_precision(pcap_thread_t* pcap_thread, const int timestamp_precision);
-int pcap_thread_immediate_mode(const pcap_thread_t* pcap_thread);
-int pcap_thread_set_immediate_mode(pcap_thread_t* pcap_thread, const int immediate_mode);
-pcap_direction_t pcap_thread_direction(const pcap_thread_t* pcap_thread);
-int pcap_thread_set_direction(pcap_thread_t* pcap_thread, const pcap_direction_t direction);
-const char* pcap_thread_filter(const pcap_thread_t* pcap_thread);
-int pcap_thread_set_filter(pcap_thread_t* pcap_thread, const char* filter, const size_t filter_len);
-int pcap_thread_clear_filter(pcap_thread_t* pcap_thread);
-int pcap_thread_filter_errno(const pcap_thread_t* pcap_thread);
-int pcap_thread_filter_optimize(const pcap_thread_t* pcap_thread);
-int pcap_thread_set_filter_optimize(pcap_thread_t* pcap_thread, const int filter_optimize);
-bpf_u_int32 pcap_thread_filter_netmask(const pcap_thread_t* pcap_thread);
-int pcap_thread_set_filter_netmask(pcap_thread_t* pcap_thread, const bpf_u_int32 filter_netmask);
-struct timeval pcap_thread_timedrun(const pcap_thread_t* pcap_thread);
-int pcap_thread_set_timedrun(pcap_thread_t* pcap_thread, const struct timeval timedrun);
-struct timeval pcap_thread_timedrun_to(const pcap_thread_t* pcap_thread);
-int pcap_thread_set_timedrun_to(pcap_thread_t* pcap_thread, const struct timeval timedrun_to);
+int                         pcap_thread_use_threads(const pcap_thread_t* pcap_thread);
+int                         pcap_thread_set_use_threads(pcap_thread_t* pcap_thread, const int use_threads);
+int                         pcap_thread_use_layers(const pcap_thread_t* pcap_thread);
+int                         pcap_thread_set_use_layers(pcap_thread_t* pcap_thread, const int use_layers);
+pcap_thread_queue_mode_t    pcap_thread_queue_mode(const pcap_thread_t* pcap_thread);
+int                         pcap_thread_set_queue_mode(pcap_thread_t* pcap_thread, const pcap_thread_queue_mode_t queue_mode);
+struct timeval              pcap_thread_queue_wait(const pcap_thread_t* pcap_thread);
+int                         pcap_thread_set_queue_wait(pcap_thread_t* pcap_thread, const struct timeval queue_wait);
+pcap_thread_queue_mode_t    pcap_thread_callback_queue_mode(const pcap_thread_t* pcap_thread);
+int                         pcap_thread_set_callback_queue_mode(pcap_thread_t* pcap_thread, const pcap_thread_queue_mode_t callback_queue_mode);
+struct timeval              pcap_thread_callback_queue_wait(const pcap_thread_t* pcap_thread);
+int                         pcap_thread_set_callback_queue_wait(pcap_thread_t* pcap_thread, const struct timeval callback_queue_wait);
+int                         pcap_thread_snapshot(const pcap_thread_t* pcap_thread);
+int                         pcap_thread_snaplen(const pcap_thread_t* pcap_thread);
+int                         pcap_thread_set_snaplen(pcap_thread_t* pcap_thread, const int snaplen);
+int                         pcap_thread_promiscuous(const pcap_thread_t* pcap_thread);
+int                         pcap_thread_set_promiscuous(pcap_thread_t* pcap_thread, const int promiscuous);
+int                         pcap_thread_monitor(const pcap_thread_t* pcap_thread);
+int                         pcap_thread_set_monitor(pcap_thread_t* pcap_thread, const int monitor);
+int                         pcap_thread_timeout(const pcap_thread_t* pcap_thread);
+int                         pcap_thread_set_timeout(pcap_thread_t* pcap_thread, const int timeout);
+int                         pcap_thread_buffer_size(const pcap_thread_t* pcap_thread);
+int                         pcap_thread_set_buffer_size(pcap_thread_t* pcap_thread, const int buffer_size);
+int                         pcap_thread_timestamp_type(const pcap_thread_t* pcap_thread);
+int                         pcap_thread_set_timestamp_type(pcap_thread_t* pcap_thread, const int timestamp_type);
+int                         pcap_thread_timestamp_precision(const pcap_thread_t* pcap_thread);
+int                         pcap_thread_set_timestamp_precision(pcap_thread_t* pcap_thread, const int timestamp_precision);
+int                         pcap_thread_immediate_mode(const pcap_thread_t* pcap_thread);
+int                         pcap_thread_set_immediate_mode(pcap_thread_t* pcap_thread, const int immediate_mode);
+pcap_direction_t            pcap_thread_direction(const pcap_thread_t* pcap_thread);
+int                         pcap_thread_set_direction(pcap_thread_t* pcap_thread, const pcap_direction_t direction);
+const char*                 pcap_thread_filter(const pcap_thread_t* pcap_thread);
+int                         pcap_thread_set_filter(pcap_thread_t* pcap_thread, const char* filter, const size_t filter_len);
+int                         pcap_thread_clear_filter(pcap_thread_t* pcap_thread);
+int                         pcap_thread_filter_errno(const pcap_thread_t* pcap_thread);
+int                         pcap_thread_filter_optimize(const pcap_thread_t* pcap_thread);
+int                         pcap_thread_set_filter_optimize(pcap_thread_t* pcap_thread, const int filter_optimize);
+bpf_u_int32                 pcap_thread_filter_netmask(const pcap_thread_t* pcap_thread);
+int                         pcap_thread_set_filter_netmask(pcap_thread_t* pcap_thread, const bpf_u_int32 filter_netmask);
+struct timeval              pcap_thread_timedrun(const pcap_thread_t* pcap_thread);
+int                         pcap_thread_set_timedrun(pcap_thread_t* pcap_thread, const struct timeval timedrun);
+struct timeval              pcap_thread_timedrun_to(const pcap_thread_t* pcap_thread);
+int                         pcap_thread_set_timedrun_to(pcap_thread_t* pcap_thread, const struct timeval timedrun_to);
 pcap_thread_activate_mode_t pcap_thread_activate_mode(const pcap_thread_t* pcap_thread);
-int pcap_thread_set_activate_mode(pcap_thread_t* pcap_thread, const pcap_thread_activate_mode_t activate_mode);
-int pcap_thread_was_stopped(const pcap_thread_t* pcap_thread);
+int                         pcap_thread_set_activate_mode(pcap_thread_t* pcap_thread, const pcap_thread_activate_mode_t activate_mode);
+int                         pcap_thread_was_stopped(const pcap_thread_t* pcap_thread);
 
 size_t pcap_thread_queue_size(const pcap_thread_t* pcap_thread);
-int pcap_thread_set_queue_size(pcap_thread_t* pcap_thread, const size_t queue_size);
+int    pcap_thread_set_queue_size(pcap_thread_t* pcap_thread, const size_t queue_size);
 
 int pcap_thread_set_callback(pcap_thread_t* pcap_thread, pcap_thread_callback_t callback);
 int pcap_thread_set_dropback(pcap_thread_t* pcap_thread, pcap_thread_callback_t dropback);
@@ -629,7 +633,7 @@ int pcap_thread_stop(pcap_thread_t* pcap_thread);
 
 int pcap_thread_stats(pcap_thread_t* pcap_thread, pcap_thread_stats_callback_t callback, u_char* user);
 
-int pcap_thread_status(const pcap_thread_t* pcap_thread);
+int         pcap_thread_status(const pcap_thread_t* pcap_thread);
 const char* pcap_thread_errbuf(const pcap_thread_t* pcap_thread);
 const char* pcap_thread_strerr(int error);
 

--- a/pcap_thread_ext_frag.c
+++ b/pcap_thread_ext_frag.c
@@ -51,10 +51,10 @@
  * Forward declares for callbacks
  */
 
-static void* pcap_thread_layer_callback_frag_new(void* conf, u_char* user);
-static void pcap_thread_layer_callback_frag_free(void* _ctx);
+static void*                      pcap_thread_layer_callback_frag_new(void* conf, u_char* user);
+static void                       pcap_thread_layer_callback_frag_free(void* _ctx);
 static pcap_thread_packet_state_t pcap_thread_layer_callback_frag_reassemble(void* _ctx, const pcap_thread_packet_t* packet, const u_char* payload, size_t length, pcap_thread_packet_t** whole_packet, const u_char** whole_payload, size_t* whole_length);
-static void pcap_thread_layer_callback_frag_release(void* _ctx, const pcap_thread_packet_t* packet, const u_char* payload, size_t length);
+static void                       pcap_thread_layer_callback_frag_release(void* _ctx, const pcap_thread_packet_t* packet, const u_char* payload, size_t length);
 
 /*
  * Create/Free
@@ -599,7 +599,7 @@ static pcap_thread_packet_state_t reassemble_ipv4(_ctx_t* ctx, const pcap_thread
         ts.tv_usec %= 1000000;
         if (packet->pkthdr.ts.tv_sec > ts.tv_sec
             || (packet->pkthdr.ts.tv_sec == ts.tv_sec
-                   && packet->pkthdr.ts.tv_usec > ts.tv_usec)) {
+                && packet->pkthdr.ts.tv_usec > ts.tv_usec)) {
 
             pcap_thread_ext_frag_fragment_t* f;
 
@@ -695,7 +695,7 @@ static pcap_thread_packet_state_t reassemble_ipv6(_ctx_t* ctx, const pcap_thread
             && packet->ip6frag.ip6f_ident == frags->packet.ip6frag.ip6f_ident
             && !memcmp(&(packet->ip6hdr.ip6_src), &(frags->packet.ip6hdr.ip6_src), sizeof(struct in6_addr))
             && ((!packet->have_ip6rtdst && !memcmp(&(packet->ip6hdr.ip6_dst), &(frags->packet.ip6hdr.ip6_dst), sizeof(struct in6_addr)))
-                   || (packet->have_ip6rtdst && !memcmp(&(packet->ip6rtdst), &(frags->packet.ip6hdr.ip6_dst), sizeof(struct in6_addr))))) {
+                || (packet->have_ip6rtdst && !memcmp(&(packet->ip6rtdst), &(frags->packet.ip6hdr.ip6_dst), sizeof(struct in6_addr))))) {
 
             layer_tracef("frags %x found", packet->ip6frag.ip6f_ident);
 
@@ -721,7 +721,7 @@ static pcap_thread_packet_state_t reassemble_ipv6(_ctx_t* ctx, const pcap_thread
         ts.tv_usec %= 1000000;
         if (packet->pkthdr.ts.tv_sec > ts.tv_sec
             || (packet->pkthdr.ts.tv_sec == ts.tv_sec
-                   && packet->pkthdr.ts.tv_usec > ts.tv_usec)) {
+                && packet->pkthdr.ts.tv_usec > ts.tv_usec)) {
 
             pcap_thread_ext_frag_fragment_t* f;
 
@@ -836,7 +836,7 @@ static void _release(_ctx_t* ctx, const pcap_thread_packet_t* packet)
                    && packet->ip6frag.ip6f_ident == frags->packet.ip6frag.ip6f_ident
                    && !memcmp(&(packet->ip6hdr.ip6_src), &(frags->packet.ip6hdr.ip6_src), sizeof(struct in6_addr))
                    && ((!packet->have_ip6rtdst && !memcmp(&(packet->ip6hdr.ip6_dst), &(frags->packet.ip6hdr.ip6_dst), sizeof(struct in6_addr)))
-                          || (packet->have_ip6rtdst && !memcmp(&(packet->ip6rtdst), &(frags->packet.ip6hdr.ip6_dst), sizeof(struct in6_addr))))) {
+                       || (packet->have_ip6rtdst && !memcmp(&(packet->ip6rtdst), &(frags->packet.ip6hdr.ip6_dst), sizeof(struct in6_addr))))) {
 
             layer_tracef("release frags %x", packet->ip6frag.ip6f_ident);
             break;
@@ -971,10 +971,10 @@ static void pcap_thread_layer_callback_frag_release(void* _ctx, const pcap_threa
                 && packet->iphdr.ip_src.s_addr == frags->packet.iphdr.ip_src.s_addr
                 && packet->iphdr.ip_dst.s_addr == frags->packet.iphdr.ip_dst.s_addr)
             || (frags->packet.have_ip6hdr
-                   && packet->ip6frag.ip6f_ident == frags->packet.ip6frag.ip6f_ident
-                   && !memcmp(&(packet->ip6hdr.ip6_src), &(frags->packet.ip6hdr.ip6_src), sizeof(struct in6_addr))
-                   && ((!packet->have_ip6rtdst && !memcmp(&(packet->ip6hdr.ip6_dst), &(frags->packet.ip6hdr.ip6_dst), sizeof(struct in6_addr)))
-                          || (packet->have_ip6rtdst && !memcmp(&(packet->ip6rtdst), &(frags->packet.ip6hdr.ip6_dst), sizeof(struct in6_addr)))))) {
+                && packet->ip6frag.ip6f_ident == frags->packet.ip6frag.ip6f_ident
+                && !memcmp(&(packet->ip6hdr.ip6_src), &(frags->packet.ip6hdr.ip6_src), sizeof(struct in6_addr))
+                && ((!packet->have_ip6rtdst && !memcmp(&(packet->ip6hdr.ip6_dst), &(frags->packet.ip6hdr.ip6_dst), sizeof(struct in6_addr)))
+                    || (packet->have_ip6rtdst && !memcmp(&(packet->ip6rtdst), &(frags->packet.ip6hdr.ip6_dst), sizeof(struct in6_addr)))))) {
 
             /* Found it, remove from list */
             if (frags_prev) {

--- a/pcap_thread_ext_frag.h
+++ b/pcap_thread_ext_frag.h
@@ -103,24 +103,24 @@ struct pcap_thread_ext_frag_conf {
 };
 
 pcap_thread_ext_frag_conf_t* pcap_thread_ext_frag_conf_new(void);
-void pcap_thread_ext_frag_conf_free(pcap_thread_ext_frag_conf_t* conf);
+void                         pcap_thread_ext_frag_conf_free(pcap_thread_ext_frag_conf_t* conf);
 
-int pcap_thread_ext_frag_conf_reject_overlap(const pcap_thread_ext_frag_conf_t* conf);
-int pcap_thread_ext_frag_conf_set_reject_overlap(pcap_thread_ext_frag_conf_t* conf, const int reject_overlap);
-int pcap_thread_ext_frag_conf_check_timeout(const pcap_thread_ext_frag_conf_t* conf);
-int pcap_thread_ext_frag_conf_set_check_timeout(pcap_thread_ext_frag_conf_t* conf, const int check_timeout);
+int                                    pcap_thread_ext_frag_conf_reject_overlap(const pcap_thread_ext_frag_conf_t* conf);
+int                                    pcap_thread_ext_frag_conf_set_reject_overlap(pcap_thread_ext_frag_conf_t* conf, const int reject_overlap);
+int                                    pcap_thread_ext_frag_conf_check_timeout(const pcap_thread_ext_frag_conf_t* conf);
+int                                    pcap_thread_ext_frag_conf_set_check_timeout(pcap_thread_ext_frag_conf_t* conf, const int check_timeout);
 pcap_thread_ext_frag_reassemble_mode_t pcap_thread_ext_frag_conf_reassemble_mode(const pcap_thread_ext_frag_conf_t* conf);
-int pcap_thread_ext_frag_conf_set_reassemble_mode(pcap_thread_ext_frag_conf_t* conf, const pcap_thread_ext_frag_reassemble_mode_t reassemble_mode);
-size_t pcap_thread_ext_frag_conf_fragments(const pcap_thread_ext_frag_conf_t* conf);
-int pcap_thread_ext_frag_conf_set_fragments(pcap_thread_ext_frag_conf_t* conf, const size_t fragments);
-size_t pcap_thread_ext_frag_conf_per_packet(const pcap_thread_ext_frag_conf_t* conf);
-int pcap_thread_ext_frag_conf_set_per_packet(pcap_thread_ext_frag_conf_t* conf, const size_t per_packet);
-struct timeval pcap_thread_ext_frag_conf_timeout(const pcap_thread_ext_frag_conf_t* conf);
-int pcap_thread_ext_frag_conf_set_timeout(pcap_thread_ext_frag_conf_t* conf, const struct timeval timeout);
-pcap_thread_ext_frag_callback_t pcap_thread_ext_frag_conf_overlap_callback(const pcap_thread_ext_frag_conf_t* conf);
-int pcap_thread_ext_frag_conf_set_overlap_callback(pcap_thread_ext_frag_conf_t* conf, pcap_thread_ext_frag_callback_t overlap_callback);
-pcap_thread_ext_frag_callback_t pcap_thread_ext_frag_conf_timeout_callback(const pcap_thread_ext_frag_conf_t* conf);
-int pcap_thread_ext_frag_conf_set_timeout_callback(pcap_thread_ext_frag_conf_t* conf, pcap_thread_ext_frag_callback_t timeout_callback);
+int                                    pcap_thread_ext_frag_conf_set_reassemble_mode(pcap_thread_ext_frag_conf_t* conf, const pcap_thread_ext_frag_reassemble_mode_t reassemble_mode);
+size_t                                 pcap_thread_ext_frag_conf_fragments(const pcap_thread_ext_frag_conf_t* conf);
+int                                    pcap_thread_ext_frag_conf_set_fragments(pcap_thread_ext_frag_conf_t* conf, const size_t fragments);
+size_t                                 pcap_thread_ext_frag_conf_per_packet(const pcap_thread_ext_frag_conf_t* conf);
+int                                    pcap_thread_ext_frag_conf_set_per_packet(pcap_thread_ext_frag_conf_t* conf, const size_t per_packet);
+struct timeval                         pcap_thread_ext_frag_conf_timeout(const pcap_thread_ext_frag_conf_t* conf);
+int                                    pcap_thread_ext_frag_conf_set_timeout(pcap_thread_ext_frag_conf_t* conf, const struct timeval timeout);
+pcap_thread_ext_frag_callback_t        pcap_thread_ext_frag_conf_overlap_callback(const pcap_thread_ext_frag_conf_t* conf);
+int                                    pcap_thread_ext_frag_conf_set_overlap_callback(pcap_thread_ext_frag_conf_t* conf, pcap_thread_ext_frag_callback_t overlap_callback);
+pcap_thread_ext_frag_callback_t        pcap_thread_ext_frag_conf_timeout_callback(const pcap_thread_ext_frag_conf_t* conf);
+int                                    pcap_thread_ext_frag_conf_set_timeout_callback(pcap_thread_ext_frag_conf_t* conf, pcap_thread_ext_frag_callback_t timeout_callback);
 
 pcap_thread_layer_callback_frag_t pcap_thread_ext_frag_layer_callback(pcap_thread_ext_frag_conf_t* conf);
 


### PR DESCRIPTION
- `pcap_thread_run`: For non-threaded mode, when using timed run, use `pcap_breakloop` if packets arriving are passed end time to prevent infinitive `pcap_dispatch` during high load
- Use PCAP error defines
- `hexdump`: Fix compile warning
- Use non-specific `clang-format` and format code