### PR TITLE
sys/time.h

### DIFF
--- a/hexdump/hexdump.c
+++ b/hexdump/hexdump.c
@@ -42,16 +42,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#ifdef TIME_WITH_SYS_TIME
-#include <sys/time.h>
-#include <time.h>
-#else
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
-#else
+#endif
 #include <time.h>
-#endif
-#endif
 #include <unistd.h>
 
 int report_padding = 0;


### PR DESCRIPTION
- `hexdump`: Clean up autotools update of `sys/time.h` handling